### PR TITLE
Allow ISA extensions in parse_iss_yaml

### DIFF
--- a/run.py
+++ b/run.py
@@ -147,7 +147,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
             cmd = re.sub("\<path_var\>",
                          get_env_var(entry['path_var'], debug_cmd=debug_cmd),
                          cmd)
-            m = re.search(r"rv(?P<xlen>[0-9]+?)(?P<variant>[a-z]+?)$", isa)
+            m = re.search(r"rv(?P<xlen>[0-9]+?)(?P<variant>[a-z]+?)(:?_.*)?$", isa)
             if m:
                 cmd = re.sub("\<xlen\>", m.group('xlen'), cmd)
             else:


### PR DESCRIPTION
At lowRISC, we're using `rv32imc_Zba_Zbb_Zbc_Zbs_Xbitmanip` as our ISA
string. This has xlen "32", variant "imc" and then some other flags
denoting extensions.

The existing code worked just fine for Spike (the ISS we're most
interested in), because the YAML entry for Spike doesn't actually use
the '`<xlen>`' or '`<variant>`' variables. But it printed out an "Illegal
ISA" error message, which is a bit confusing.

Fix that, by allowing (and ignoring) ISA extension flags.