### PR TITLE
Fix XLEN assumption in riscv_instr_pkg

### DIFF
--- a/src/riscv_instr_pkg.sv
+++ b/src/riscv_instr_pkg.sv
@@ -1380,7 +1380,7 @@ package riscv_instr_pkg;
     string store_instr = (XLEN == 32) ? "sw" : "sd";
     if (scratch inside {implemented_csr}) begin
       // Push USP from gpr.SP onto the kernel stack
-      instr.push_back($sformatf("addi x%0d, x%0d, -4", tp, tp));
+      instr.push_back($sformatf("addi x%0d, x%0d, %d", tp, tp, (XLEN/8)));
       instr.push_back($sformatf("%0s  x%0d, (x%0d)", store_instr, sp, tp));
       // Move KSP to gpr.SP
       instr.push_back($sformatf("add x%0d, x%0d, zero", sp, tp));


### PR DESCRIPTION
This assumption causes an unaligned store on 64b processor in some cases. This fix should preserve behavior on 32b processors but allow for aligned 64b store