### PR TITLE
Fix RV32 support

### DIFF
--- a/euvm/riscv/gen/riscv_asm_program_gen.d
+++ b/euvm/riscv/gen/riscv_asm_program_gen.d
@@ -736,7 +736,7 @@ class riscv_asm_program_gen : uvm_object
   }
 
   // get a random double precision floating value
-  ubvec!XLEN get_rand_dpf_value() {
+  ubvec!64 get_rand_dpf_value() {
     ubvec!64 value;
 
     int randint = urandom(0,6);

--- a/euvm/riscv/gen/riscv_load_store_instr_lib.d
+++ b/euvm/riscv/gen/riscv_load_store_instr_lib.d
@@ -670,11 +670,11 @@ class riscv_vector_load_store_instr_stream : riscv_mem_access_stream
     add_mixed_instr(num_mixed_instr);
     add_rs1_init_la_instr(rs1_reg, data_page_id, base);
     if (address_mode == address_mode_e.STRIDED) {
-      this.append_instr(get_init_gpr_instr(rs2_reg, toubvec!64(stride_byte_offset)));
+      this.append_instr(get_init_gpr_instr(rs2_reg, toubvec!XLEN(stride_byte_offset)));
     }
     else if (address_mode == address_mode_e.INDEXED) {
       // TODO: Support different index address for each element
-      add_init_vector_gpr_instr(vs2_reg, toubvec!64(index_addr));
+      add_init_vector_gpr_instr(vs2_reg, toubvec!XLEN(index_addr));
     }
     super.post_randomize();
   }

--- a/euvm/riscv/gen/riscv_page_table_entry.d
+++ b/euvm/riscv/gen/riscv_page_table_entry.d
@@ -161,7 +161,7 @@ class riscv_page_table_entry(satp_mode_t MODE = satp_mode_t.SV39) : uvm_object
   void pack_entry() {
     switch (MODE) {
     case satp_mode_t.SV32:
-      bits = ppn1 ~ ppn0 ~ rsw ~ d ~ a ~ g ~ u ~ xwr ~ v;
+      bits = cast(ubvec!XLEN) (ppn1 ~ ppn0 ~ rsw ~ d ~ a ~ g ~ u ~ xwr ~ v);
       break;
     case satp_mode_t.SV39:
       bits = cast(ubvec!XLEN) (rsvd ~ ppn2 ~ ppn1 ~ ppn0 ~ rsw ~ d ~ a ~ g ~ u ~ xwr ~ v);

--- a/euvm/riscv/gen/riscv_privileged_common_seq.d
+++ b/euvm/riscv/gen/riscv_privileged_common_seq.d
@@ -123,16 +123,18 @@ class riscv_privileged_common_seq : uvm_sequence!(uvm_sequence_item,uvm_sequence
     mstatus.set_field("TW", cfg.set_mstatus_tw);
     mstatus.set_field("FS", cfg.mstatus_fs);
     mstatus.set_field("VS", cfg.mstatus_vs);
-    if (!(canFind(supported_privileged_mode, privileged_mode_t.SUPERVISOR_MODE) && (XLEN != 32))) {
-      mstatus.set_field("SXL", toubvec!2(0b00));
-    }
-    else if (XLEN == 64) {
-      mstatus.set_field("SXL", toubvec!2(0b10));
-    }
-    if (!(canFind(supported_privileged_mode, privileged_mode_t.USER_MODE) && (XLEN != 32))) {
-      mstatus.set_field("UXL", toubvec!2(0b00));
-    } else if (XLEN == 64) {
-      mstatus.set_field("UXL", toubvec!2(0b10));
+    if (XLEN != 32) {
+      if (!(canFind(supported_privileged_mode, privileged_mode_t.SUPERVISOR_MODE))) {
+        mstatus.set_field("SXL", toubvec!2(0b00));
+      }
+      else if (XLEN == 64) {
+        mstatus.set_field("SXL", toubvec!2(0b10));
+      }
+      if (!(canFind(supported_privileged_mode, privileged_mode_t.USER_MODE))) {
+        mstatus.set_field("UXL", toubvec!2(0b00));
+      } else if (XLEN == 64) {
+        mstatus.set_field("UXL", toubvec!2(0b10));
+      }
     }
     mstatus.set_field("XS", 0);
     mstatus.set_field("SD", 0);


### PR DESCRIPTION
Currently it is impossible to compile the eUVM-based instruction generator for RV32 due to errors in the code. This PR fixes those errors.