### PR TITLE
PyFlow log trace to csv improvements and Renode ISS support

### DIFF
--- a/run.py
+++ b/run.py
@@ -662,7 +662,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
                     prefix = ("{}/asm_test/{}_{}".format(
                         output_dir, test['test'], i))
                     elf = prefix + ".o"
-                    log = ("{}/{}.{}.log".format(log_dir, test['test'], i))
+                    log = ("{}/{}_{}.log".format(log_dir, test['test'], i))
                     cmd = get_iss_cmd(base_cmd, elf, log)
                     if 'iss_opts' in test:
                         cmd += ' '

--- a/run.py
+++ b/run.py
@@ -139,6 +139,11 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
     """
     logging.info("Processing ISS setup file : {}".format(iss_yaml))
     yaml_data = read_yaml(iss_yaml)
+
+    # Path to the "scripts" subdirectory
+    my_path = os.path.dirname(os.path.realpath(__file__))
+    scripts_dir = os.path.join(my_path, "scripts")   # Search for matched ISS
+
     # Search for matched ISS
     for entry in yaml_data:
         if entry['iss'] == iss:
@@ -161,6 +166,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
                     cmd = re.sub("\<variant\>", variant, cmd)
             else:
                 cmd = re.sub("\<variant\>", isa, cmd)
+            cmd = re.sub("\<scripts_path\>", scripts_dir, cmd)
             return cmd
     logging.error("Cannot find ISS {}".format(iss))
     sys.exit(RET_FAIL)

--- a/scripts/renode_log_to_trace_csv.py
+++ b/scripts/renode_log_to_trace_csv.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Converts Renode log to execution trace for RISC-V DV
+"""
+
+import argparse
+import os
+import re
+import sys
+import logging
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+from riscv_trace_csv import *
+from lib import *
+
+# =============================================================================
+
+GPR_NAMES = [
+    ("x0",  "zero"),
+    ("x1",  "ra"),
+    ("x2",  "sp"),
+    ("x3",  "gp"),
+    ("x4",  "tp"),
+    ("x5",  "t0"),
+    ("x6",  "t1"),
+    ("x7",  "t2"),
+    ("x8",  "s0"),
+    ("x9",  "s1"),
+    ("x10", "a0"),
+    ("x11", "a1"),
+    ("x12", "a2"),
+    ("x13", "a3"),
+    ("x14", "a4"),
+    ("x15", "a5"),
+    ("x16", "a6"),
+    ("x17", "a7"),
+    ("x18", "s2"),
+    ("x19", "s3"),
+    ("x20", "s4"),
+    ("x21", "s5"),
+    ("x22", "s6"),
+    ("x23", "s7"),
+    ("x24", "s8"),
+    ("x25", "s9"),
+    ("x26", "s10"),
+    ("x27", "s11"),
+    ("x28", "t3"),
+    ("x29", "t4"),
+    ("x30", "t5"),
+    ("x31", "t6"),
+]
+
+# =============================================================================
+
+
+def process_renode_sim_log(log_name, csv_name):
+    """
+    Converts a Renode trace log to CSV format
+    """
+
+    # Build lookups
+    gpr_to_name = {m[0]: m[1] for m in GPR_NAMES}
+    known_gpr = {m[0].upper() for m in GPR_NAMES}
+
+    # FIXME: We need a previous PC each time. Assume its value for the first
+    # entry.
+    prev_pc = "80000000"
+
+    # FIXME: Assume initial state of all GPR set to 0
+    state   = {m[0].upper(): "0" for m in GPR_NAMES}
+    trace   = []
+
+    with open(log_name, "r") as fp:
+        for line in fp:
+
+            line = line.strip()
+            if not line:
+                continue
+
+            # Skip non-regdump
+            if not line.startswith("REGDUMP:"):
+                continue
+
+            # Decode state
+            fields = line.replace("REGDUMP:", "").split(",")
+            regs = {fields[i]: fields[i+1] for i in range(0, len(fields), 2)}
+
+            # Compute state difference
+            diff  = {r: regs[r] for r in known_gpr \
+                     if r in state and r in regs and state[r] != regs[r]}
+            state = regs
+
+            # Format the entry
+            entry = RiscvInstructionTraceEntry()
+            entry.pc        = prev_pc
+            entry.binary    = "0"
+            entry.operand   = ""
+            entry.mode      = "0"
+
+            # GPRs
+            for x in range(32):
+                name = "X{}".format(x)
+                if name in diff:
+                    lname = name.lower()
+                    value = int(diff[name], 16)
+                    entry.gpr.append("{}:{:08x}".format(gpr_to_name[lname], value))
+
+            # CSRs
+            # TODO:
+
+            # Add only if there is a GPR/CSR change
+            if entry.gpr or entry.csr:
+                trace.append(entry)
+
+            prev_pc = state["PC"]
+
+    return trace
+
+
+def write_csv(file_name, data):
+    """
+    Writes the trace to CSV
+    """
+
+    with open(file_name, "w") as fp:
+
+        writer = RiscvInstructionTraceCsv(fp)
+        writer.start_new_trace()
+
+        for entry in data:
+            writer.write_trace_entry(entry)
+
+# ============================================================================
+
+
+def main():
+    # Parse input arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log", type=str, help="Input Renode simulation log")
+    parser.add_argument("--csv", type=str, help="Output trace CSV file")
+    parser.add_argument("-v", "--verbose", dest="verbose", action="store_true",
+                        help="Verbose logging")
+    parser.set_defaults(verbose=False)
+
+    args = parser.parse_args()
+    setup_logging(args.verbose)
+
+    # Process Renode log
+    trace = process_renode_sim_log(args.log, args.csv)
+    # Write CSV
+    write_csv(args.csv, trace)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import os
+import tempfile
+
+# =============================================================================
+
+REPL_TEMPLATE = """
+memory: Memory.MappedMemory @ sysbus 0x80000000
+    size: 0x10000
+
+cpu: CPU.RiscV32 @ sysbus
+    cpuType: "{isa}"
+    timeProvider: clint
+    hartId: 0
+
+clint: IRQControllers.CoreLevelInterruptor  @ sysbus 0x02000000
+    [0,1] -> cpu@[3,7]
+    frequency: 1000000
+"""
+
+RESC_TEMPLATE = """
+using sysbus
+mach create "riscv"
+machine LoadPlatformDescription @{repl}
+
+sysbus LoadELF @{elf}
+
+cpu MaximumBlockSize 1
+cpu SetHookAtBlockEnd "print('REGDUMP:' + ','.join(self.GetRegistersValues()))"
+
+emulation RunFor "0.000100"
+
+quit
+"""
+
+# =============================================================================
+
+
+def main():
+    """
+    The entry point
+    """
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--renode",
+        type=str,
+        default="renode",
+        help="Path to Renode binary",
+    )
+    parser.add_argument(
+        "--log",
+        type=str,
+        default=None,
+        help="Output log file",
+    )
+    parser.add_argument(
+        "--isa",
+        type=str,
+        default="rv32i",
+        help="RISC-V ISA specification string",
+    )
+    parser.add_argument(
+        "--elf",
+        type=str,
+        required=True,
+        help="ELF file to run",
+    )
+
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+
+        repl = os.path.join(tmpdir, "riscv.repl")
+        resc = os.path.join(tmpdir, "riscv.resc")
+
+        params = {
+            "renode": args.renode,
+            "isa":  args.isa,
+            "elf":  args.elf,
+            "repl": repl,
+            "resc": resc,
+            "log":  args.log,
+        }
+
+        # Render REPL template
+        with open(repl, "w") as fp:
+            fp.write(REPL_TEMPLATE.format(**params))
+
+        # Render RESC template
+        with open(resc, "w") as fp:
+            fp.write(RESC_TEMPLATE.format(**params))
+
+        # Launch Renode, capture output
+        cmd = "{renode} --console -p {resc}".format(**params)
+        if args.log is not None:
+            cmd += " &>{log}".format(**params)
+
+        subprocess.call(cmd, shell=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spike_log_to_trace_csv.py
+++ b/scripts/spike_log_to_trace_csv.py
@@ -27,10 +27,10 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from riscv_trace_csv import *
 from lib import *
 
-RD_RE = re.compile(r"(core\s+\d+:\s+)?(?P<pri>\d) 0x(?P<addr>[a-f0-9]+?) " \
-                   "\((?P<bin>.*?)\) (?P<reg>[xf]\s*\d*?) 0x(?P<val>[a-f0-9]+)")
+RD_RE = re.compile(r"(core\s+\d+:\s+)?(?P<pri>\d)\s+0x(?P<addr>[a-f0-9]+?)\s+" \
+                   "\((?P<bin>.*?)\)\s+(?P<reg>[xf]\s*\d*?)\s+0x(?P<val>[a-f0-9]+)")
 CORE_RE = re.compile(
-    r"core\s+\d+:\s+0x(?P<addr>[a-f0-9]+?) \(0x(?P<bin>.*?)\) (?P<instr>.*?)$")
+    r"core\s+\d+:\s+0x(?P<addr>[a-f0-9]+?)\s+\(0x(?P<bin>.*?)\)\s+(?P<instr>.*?)$")
 ADDR_RE = re.compile(
     r"(?P<rd>[a-z0-9]+?),(?P<imm>[\-0-9]+?)\((?P<rs1>[a-z0-9]+)\)")
 ILLE_RE = re.compile(r"trap_illegal_instruction")

--- a/scripts/spike_log_to_trace_csv.py
+++ b/scripts/spike_log_to_trace_csv.py
@@ -27,8 +27,10 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 from riscv_trace_csv import *
 from lib import *
 
-RD_RE = re.compile(r"(core\s+\d+:\s+)?(?P<pri>\d)\s+0x(?P<addr>[a-f0-9]+?)\s+" \
-                   "\((?P<bin>.*?)\)\s+(?P<reg>[xf]\s*\d*?)\s+0x(?P<val>[a-f0-9]+)")
+RD_RE = re.compile(
+    r"(core\s+\d+:\s+)?(?P<pri>\d)\s+0x(?P<addr>[a-f0-9]+?)\s+" \
+    r"\((?P<bin>.*?)\)\s+(?P<reg>[xf]\s*\d*?)\s+0x(?P<val>[a-f0-9]+)" \
+    r"(\s+(?P<csr>\S+)\s+0x(?P<csr_val>[a-f0-9]+))?")
 CORE_RE = re.compile(
     r"core\s+\d+:\s+0x(?P<addr>[a-f0-9]+?)\s+\(0x(?P<bin>.*?)\)\s+(?P<instr>.*?)$")
 ADDR_RE = re.compile(
@@ -173,9 +175,13 @@ def read_spike_trace(path, full_trace):
             # the --log-commits Spike option)?
             commit_match = RD_RE.match(line)
             if commit_match:
-                instr.gpr.append(gpr_to_abi(commit_match.group('reg')
-                                            .replace(' ', '')) +
-                                 ':' + commit_match.group('val'))
+                groups = commit_match.groupdict()
+                instr.gpr.append(gpr_to_abi(groups["reg"].replace(' ', '')) +
+                                 ":" + groups["val"])
+
+                if groups["csr"] and groups["csr_val"]:
+                    instr.csr.append(groups["csr"] + ":" + groups["csr_val"])
+
                 instr.mode = commit_match.group('pri')
 
         # At EOF, we might have an instruction in hand. Yield it if so.

--- a/scripts/whisper_log_trace_csv.py
+++ b/scripts/whisper_log_trace_csv.py
@@ -60,6 +60,7 @@ def process_whisper_sim_log(whisper_log, csv, full_trace=0):
                     whisper_instr = m.group("instr").replace("\. +  ", "")
                     whisper_instr = whisper_instr.replace("\. - ", "-")
                     rv_instr_trace = RiscvInstructionTraceEntry()
+                    rv_instr_trace.pc = m.group("pc")
                     rv_instr_trace.instr_str = whisper_instr
                     rv_instr_trace.binary = m.group("bin")
                     reg = "x" + str(int(m.group("reg"), 16))

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -36,3 +36,8 @@
   path_var: WHISPER_ISS
   cmd: >
     <path_var> <elf> --log --xlen <xlen> --isa <variant>
+
+- iss: renode
+  path_var: RENODE_PATH
+  cmd: >
+    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant>


### PR DESCRIPTION
This PR provides enhancements to the ISS used with PyFlow Instruction Generator:
- Fixed logs created with spike in a scenario with multiple spaces and enabled parsing CSR writes from them
- Log file names produced by run.py now follow the same convention
- Added missing PC values to VeeR-ISS (a.k.a. whisper) log to CSV converter
- Enabled Renode as an Instruction Set Simulator
