### PR TITLE
Fix Ctrl-C processing & use as lib with recent python versions

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -103,6 +103,12 @@ def run_cmd(cmd, timeout_s=999, exit_on_error=1, check_return_code=True,
         debug_cmd.write(cmd)
         debug_cmd.write("\n\n")
         return
+    def killgroup(ps):
+        try:
+            os.killpg(os.getpgid(ps.pid), signal.SIGTERM)
+        except AttributeError: #killpg not available on windows
+            ps.kill()
+        sys.exit(130)
     try:
         ps = subprocess.Popen("exec " + cmd,
                               shell=True,
@@ -112,21 +118,17 @@ def run_cmd(cmd, timeout_s=999, exit_on_error=1, check_return_code=True,
                               env=os.environ,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.STDOUT)
+        output = ps.communicate(timeout = timeout_s)[0]
     except subprocess.CalledProcessError:
         logging.error(ps.communicate()[0])
         sys.exit(RET_FAIL)
     except KeyboardInterrupt:
         logging.info("\nExited Ctrl-C from user request.")
-        sys.exit(130)
-    try:
-        output = ps.communicate(timeout=timeout_s)[0]
+        killgroup(ps)
     except subprocess.TimeoutExpired:
         logging.error("Timeout[{}s]: {}".format(timeout_s, cmd))
         output = ""
-        try:
-            os.killpg(os.getpgid(ps.pid), signal.SIGTERM)
-        except AttributeError: #killpg not available on windows
-            ps.kill()
+        killgroup(ps)
     rc = ps.returncode
     if rc and check_return_code and rc > 0:
         logging.info(output)


### PR DESCRIPTION
Hello,

We are using riscv-dv with two patches to verify [CVA6](https://github.com/openhwgroup/cva6/). We hope it will help everyone if those patches are made common.

1. The simulation was still running after hitting Ctrl-C. With this PR it is correctly killed. It is a continuation of work from @yanicasa fixing the same issue for timeouts.
2. We are using riscv-dv as a library with a relative path `dv.scripts`. Python 3.9 cannot find it albeit Python 3.7 had no issues finding it. To fix this, we found [this link](https://stackoverflow.com/questions/1944569/how-do-i-write-good-correct-package-init-py-files) and added an empty `__init__.py` file.