### PR TITLE
Remove unused local variables and fix gen_callback

### DIFF
--- a/pygen/pygen_src/riscv_asm_program_gen.py
+++ b/pygen/pygen_src/riscv_asm_program_gen.py
@@ -130,7 +130,7 @@ class riscv_asm_program_gen:
             if(hart == 0 and not(rcs.support_pmp)):
                 self.gen_test_done()
             # Shuffle the sub programs and insert to the instruction stream
-            self.insert_sub_program(self.sub_program[hart], self.instr_stream)
+            self.insert_sub_program(self.instr_stream)
             logging.info("Main/sub program generation...done")
             # program end
             self.gen_program_end(hart)
@@ -229,7 +229,7 @@ class riscv_asm_program_gen:
                       sub_program_name, num_sub_program):
         if num_sub_program != 0:
             callstack_gen = riscv_callstack_gen()
-            self.callstack_gen.init(num_sub_program + 1)
+            callstack_gen.init(num_sub_program + 1)
             if callstack_gen.randomize():
                 idx = 0
                 # Insert the jump instruction based on the call stack

--- a/pygen/pygen_src/riscv_callstack_gen.py
+++ b/pygen/pygen_src/riscv_callstack_gen.py
@@ -82,7 +82,7 @@ class riscv_callstack_gen:
         self.program_cnt = program_cnt
         self.program_h = [0] * program_cnt
         for i in range(len(self.program_h)):
-            self.program_h[i] = riscv_program("program_{}".format(i))
+            self.program_h[i] = riscv_program()
 
 # In the randomization stage, only the stack level of each program is specified. The call stack
 # generation process is to build the call relationship between different programs. This is


### PR DESCRIPTION
1. There are some unused local variables from function parameters so I remove them.
2. \_\_init\_\_ of class riscv_program has no input parameter but self
3. class riscv_asm_program_gen has no member 'callstack_gen'. It's a local variable in function 'gen_callstack'