### PR TITLE
allow specifying privilege modes for simulation

### DIFF
--- a/run.py
+++ b/run.py
@@ -124,13 +124,14 @@ def get_generator_cmd(simulator, simulator_yaml, cov, exp, debug_cmd):
     sys.exit(RET_FAIL)
 
 
-def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
+def parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd):
     """Parse ISS YAML to get the simulation command
 
     Args:
       iss         : target ISS used to look up in ISS YAML
       iss_yaml    : ISS configuration file in YAML format
       isa         : ISA variant passed to the ISS
+      priv:       : privilege modes
       setting_dir : Generator setting directory
       debug_cmd   : Produce the debug cmd log without running
 
@@ -169,6 +170,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
                     cmd = re.sub("\<variant\>", variant, cmd)
             else:
                 cmd = re.sub("\<variant\>", isa, cmd)
+            cmd = re.sub("\<priv\>", priv, cmd)
             cmd = re.sub("\<scripts_path\>", scripts_dir, cmd)
             cmd = re.sub("\<config_path\>", yaml_dir, cmd)
             return cmd
@@ -645,7 +647,7 @@ def run_c_from_dir(c_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
 
 
 def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
-            isa, setting_dir, timeout_s, debug_cmd):
+            isa, priv, setting_dir, timeout_s, debug_cmd):
     """Run ISS simulation with the generated test program
 
     Args:
@@ -655,13 +657,14 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
       iss_yaml    : ISS configuration file in YAML format
       iss_opts    : ISS command line options
       isa         : ISA variant passed to the ISS
+      priv        : privilege modes
       setting_dir : Generator setting directory
       timeout_s   : Timeout limit in seconds
       debug_cmd   : Produce the debug cmd log without running
     """
     for iss in iss_list.split(","):
         log_dir = ("{}/{}_sim".format(output_dir, iss))
-        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd)
         logging.info("{} sim log dir: {}".format(iss, log_dir))
         run_cmd_output(["mkdir", "-p", log_dir])
         for test in test_list:
@@ -818,6 +821,8 @@ def parse_args(cwd):
                             command is not specified")
     parser.add_argument("--isa", type=str, default="",
                         help="RISC-V ISA subset")
+    parser.add_argument("--priv", type=str, default="",
+                        help="RISC-V privilege modes enabled in simulation [su]")
     parser.add_argument("-m", "--mabi", type=str, default="",
                         help="mabi used for compilation", dest="mabi")
     parser.add_argument("--gen_timeout", type=int, default=360,
@@ -1151,7 +1156,7 @@ def main():
             if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
                 iss_sim(matched_list, output_dir, args.iss, args.iss_yaml,
                         args.iss_opts,
-                        args.isa, args.core_setting_dir, args.iss_timeout,
+                        args.isa, args.priv, args.core_setting_dir, args.iss_timeout,
                         args.debug)
 
             # Compare ISS simulation result

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --log-commits --isa=<variant> --misaligned -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> --priv=m<priv> --misaligned -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH
@@ -35,7 +35,7 @@
 - iss: whisper
   path_var: WHISPER_ISS
   cmd: >
-    <path_var> <elf> --log --xlen <xlen> --isa <variant> --configfile <config_path>/whisper.json --iccmrw
+    <path_var> <elf> --log --xlen <xlen> --isa <variant><priv> --configfile <config_path>/whisper.json --iccmrw
 
 - iss: renode
   path_var: RENODE_PATH


### PR DESCRIPTION
Currently we're using the default settings of privilege modes in ISS tools.
Whisper needs a 'u' in the ISA string for the User mode to be enabled. Spike, on the other hand, enables both Supervisor and User modes by default (it has a `--priv` arugment with the default of `msu`.)

We can make it consistent by adding an argument to select the modes to be enabled in simulation.
With these changes, the default selection is M-mode only.
The `--priv` argument allows enabling Supervisor and User mode, while Machine mode is mandatory and can't be disabled.

I would appreciate feedback on the default value for the `--priv` argument. I can see several ways to implement it here:
1. **default is `""`, which means M mode enabled, allows selecting S and U as `[su]`. (currently implemented)**
2. default is `"m"`, which means M mode enabled, allows selecting S and U as `m[su]` - in my view this is worse because M is mandatory anyway. Contrary to (1.) this doesn't use empty string for default.
3. default is `"msu"` - which means M,S,U modes are enabled. This wouldn't affect the default `spike` command line


Here's a PR in VeeR where I've proven VeeR's CI passes with these changes and `--priv u`:
https://github.com/chipsalliance/Cores-VeeR-EL2/pull/197