### PR TITLE
updated for python 3.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ qrun.log
 riscv_dv.egg-info
 pygen/pygen_src/test/out/*
 !.gitkeep
+.venv/
 

--- a/pygen/pygen_src/isa/riscv_instr.py
+++ b/pygen/pygen_src/isa/riscv_instr.py
@@ -15,7 +15,7 @@ import copy
 import sys
 import random
 import vsc
-from imp import reload
+from importlib import reload
 from collections import defaultdict
 from bitstring import BitArray
 from importlib import import_module


### PR DESCRIPTION
Renamed `imp` to `importlib` in `pygen/pygen_src/isa/riscv_instr.py`