### PR TITLE
Make renode_wrapper more configurable

### DIFF
--- a/run.py
+++ b/run.py
@@ -665,6 +665,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
     for iss in iss_list.split(","):
         log_dir = ("{}/{}_sim".format(output_dir, iss))
         base_cmd = parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd)
+        base_cmd += iss_opts
         logging.info("{} sim log dir: {}".format(iss, log_dir))
         run_cmd_output(["mkdir", "-p", log_dir])
         for test in test_list:

--- a/run.py
+++ b/run.py
@@ -124,13 +124,14 @@ def get_generator_cmd(simulator, simulator_yaml, cov, exp, debug_cmd):
     sys.exit(RET_FAIL)
 
 
-def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
+def parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd):
     """Parse ISS YAML to get the simulation command
 
     Args:
       iss         : target ISS used to look up in ISS YAML
       iss_yaml    : ISS configuration file in YAML format
       isa         : ISA variant passed to the ISS
+      priv:       : privilege modes
       setting_dir : Generator setting directory
       debug_cmd   : Produce the debug cmd log without running
 
@@ -169,6 +170,7 @@ def parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd):
                     cmd = re.sub("\<variant\>", variant, cmd)
             else:
                 cmd = re.sub("\<variant\>", isa, cmd)
+            cmd = re.sub("\<priv\>", priv, cmd)
             cmd = re.sub("\<scripts_path\>", scripts_dir, cmd)
             cmd = re.sub("\<config_path\>", yaml_dir, cmd)
             return cmd
@@ -645,7 +647,7 @@ def run_c_from_dir(c_test_dir, iss_yaml, isa, mabi, gcc_opts, iss,
 
 
 def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
-            isa, setting_dir, timeout_s, debug_cmd):
+            isa, priv, setting_dir, timeout_s, debug_cmd):
     """Run ISS simulation with the generated test program
 
     Args:
@@ -655,13 +657,14 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
       iss_yaml    : ISS configuration file in YAML format
       iss_opts    : ISS command line options
       isa         : ISA variant passed to the ISS
+      priv        : privilege modes
       setting_dir : Generator setting directory
       timeout_s   : Timeout limit in seconds
       debug_cmd   : Produce the debug cmd log without running
     """
     for iss in iss_list.split(","):
         log_dir = ("{}/{}_sim".format(output_dir, iss))
-        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, setting_dir, debug_cmd)
+        base_cmd = parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd)
         logging.info("{} sim log dir: {}".format(iss, log_dir))
         run_cmd_output(["mkdir", "-p", log_dir])
         for test in test_list:
@@ -818,6 +821,8 @@ def parse_args(cwd):
                             command is not specified")
     parser.add_argument("--isa", type=str, default="",
                         help="RISC-V ISA subset")
+    parser.add_argument("--priv", type=str, default="",
+                        help="RISC-V privilege modes enabled in simulation [su]")
     parser.add_argument("-m", "--mabi", type=str, default="",
                         help="mabi used for compilation", dest="mabi")
     parser.add_argument("--gen_timeout", type=int, default=360,
@@ -1151,7 +1156,7 @@ def main():
             if args.steps == "all" or re.match(".*iss_sim.*", args.steps):
                 iss_sim(matched_list, output_dir, args.iss, args.iss_yaml,
                         args.iss_opts,
-                        args.isa, args.core_setting_dir, args.iss_timeout,
+                        args.isa, args.priv, args.core_setting_dir, args.iss_timeout,
                         args.debug)
 
             # Compare ISS simulation result

--- a/scripts/instr_trace_compare.py
+++ b/scripts/instr_trace_compare.py
@@ -125,6 +125,8 @@ def compare_trace_csv(csv1, csv2, name1, name2, log,
                         instr_trace_2[trace_2_index].gpr,
                         gpr_val_2)
                     if gpr_state_change_2 == 1:
+                        fd.write("Mismatch[{}]:\n[{}] {} : {}\n".format(
+                            mismatch_cnt, trace_1_index, name1,trace.get_trace_string()))
                         fd.write("{} instructions left in trace {}\n".format(
                           len(instr_trace_2) - trace_2_index, name2))
                         mismatch_cnt += len(instr_trace_2) - trace_2_index

--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -14,6 +14,7 @@ cpu: CPU.{cpu_type} @ sysbus
     cpuType: "{isa}"
     timeProvider: clint
     hartId: 0
+    {priv_levels}
     {additional_cpu_parameters}
 
 clint: IRQControllers.CoreLevelInterruptor  @ sysbus 0x02000000
@@ -83,6 +84,12 @@ def main():
         default="Riscv32",
         help="Renode CPU type",
     )
+    parser.add_argument(
+        "--priv",
+        type=str,
+        default="",
+        help="Supported privilege levels",
+    )
     # Some CPUs might not expose these parameters as configurable
     # allow the testing software to ignore/override them if needed
     parser.add_argument(
@@ -99,6 +106,16 @@ def main():
         repl = os.path.join(tmpdir, "riscv.repl")
         resc = os.path.join(tmpdir, "riscv.resc")
 
+        priv_levels = ""
+        if args.priv:
+            priv_levels += "privilegeLevels: PrivilegeLevels."
+            if "m" in args.priv:
+                priv_levels += "Machine"
+            if "s" in args.priv:
+                priv_levels += "Supervisor"
+            if "u" in args.priv:
+                priv_levels += "User"
+
         params = {
             "renode": args.renode,
             "isa":  args.isa,
@@ -108,6 +125,7 @@ def main():
             "log":  args.log,
             "mem":  args.mem_size,
             "cpu_type": args.cpu_type,
+            "priv_levels": priv_levels,
             "additional_cpu_parameters": args.additional_cpu_parameters,
         }
 

--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -10,11 +10,11 @@ REPL_TEMPLATE = """
 memory: Memory.MappedMemory @ sysbus 0x80000000
     size: {mem}
 
-cpu: CPU.RiscV32 @ sysbus
+cpu: CPU.{cpu_type} @ sysbus
     cpuType: "{isa}"
     timeProvider: clint
     hartId: 0
-    allowUnalignedAccesses: true
+    {additional_cpu_parameters}
 
 clint: IRQControllers.CoreLevelInterruptor  @ sysbus 0x02000000
     [0,1] -> cpu@[3,7]
@@ -77,6 +77,20 @@ def main():
         default="0x100000",
         help="Memory size",
     )
+    parser.add_argument(
+        "--cpu-type",
+        type=str,
+        default="Riscv32",
+        help="Renode CPU type",
+    )
+    # Some CPUs might not expose these parameters as configurable
+    # allow the testing software to ignore/override them if needed
+    parser.add_argument(
+        "--additional-cpu-parameters",
+        type=str,
+        default="allowUnalignedAccesses: true",
+        help="Additional CPU parameters",
+    )
 
     args = parser.parse_args()
 
@@ -93,6 +107,8 @@ def main():
             "resc": resc,
             "log":  args.log,
             "mem":  args.mem_size,
+            "cpu_type": args.cpu_type,
+            "additional_cpu_parameters": args.additional_cpu_parameters,
         }
 
         # Render REPL template

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -40,4 +40,4 @@
 - iss: renode
   path_var: RENODE_PATH
   cmd: >
-    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --mem-size 0x80000000
+    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=m<priv> --mem-size 0x80000000

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --log-commits --isa=<variant> --misaligned -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> --priv=m<priv> --misaligned -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH
@@ -35,7 +35,7 @@
 - iss: whisper
   path_var: WHISPER_ISS
   cmd: >
-    <path_var> <elf> --log --xlen <xlen> --isa <variant> --configfile <config_path>/whisper.json --iccmrw
+    <path_var> <elf> --log --xlen <xlen> --isa <variant><priv> --configfile <config_path>/whisper.json --iccmrw
 
 - iss: renode
   path_var: RENODE_PATH

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --log-commits --isa=<variant> --priv=m<priv> --misaligned -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> --priv=<priv> --misaligned -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH
@@ -40,4 +40,4 @@
 - iss: renode
   path_var: RENODE_PATH
   cmd: >
-    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=m<priv> --mem-size 0x80000000
+    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=<priv> --mem-size 0x80000000


### PR DESCRIPTION
Allow to pass more options to `renode_wrapper` such as:
* CPU model
* privilege levels
* additional CPU constructor parameters

Also this adds an additional print to `instr_trace_compare.py` and allows to pass additional arguments to ISS with `--iss_opts=` switch.

This PR depends on: https://github.com/chipsalliance/riscv-dv/pull/984 and should be considered for merge only after those changes are applied. The first commit here is taken directly from that PR.