### PR TITLE
Improvements and fixes for VeeR-EL2 testing

### DIFF
--- a/.github/workflows/build-spike.yml
+++ b/.github/workflows/build-spike.yml
@@ -36,7 +36,7 @@ jobs:
           key: ${{ env.cache_name }}_${{ env.cache_date }}
           restore-keys: ${{ env.cache_name }}_
 
-      - name: Install prerequisities
+      - name: Install prerequisites
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,12 +22,14 @@ jobs:
         name: Prepare test types
         run: |
           python3 -m pip install pyyaml
-          echo "tests=$(python3 .github/scripts/parse_testlist.py $RISCV_TARGET)" | tee -a $GITHUB_OUTPUT
+          python3 .github/scripts/parse_testlist.py $RISCV_TARGET > tests.list
+          echo "tests=$(cat tests.list)" | tee -a $GITHUB_OUTPUT
       - id: hash
         name: Prepare files' hash
         run: |
-          echo "files-hash=$(sha256sum **/*.sv **/*.py **/*.yml **/*.yaml | cut -d\  -f1 | sha256sum | cut -d\  -f1)" | tee -a $GITHUB_OUTPUT
-          
+          sha256sum **/*.sv **/*.py **/*.yaml > file.hash
+          echo "files-hash=$(cat file.hash | cut -d\  -f1 | sha256sum | cut -d\  -f1)" | tee -a $GITHUB_OUTPUT
+
 
   generate-code:
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
@@ -39,7 +41,7 @@ jobs:
         test: ${{ fromJSON(needs.generate-config.outputs.test-types) }}
         version: [ uvm ]
         include:
-          - test: riscv_arithmetic_basic_test 
+          - test: riscv_arithmetic_basic_test
             version: pyflow
     env:
       GHA_EXTERNAL_DISK: additional-tools
@@ -89,9 +91,10 @@ jobs:
             --isa $RISCV_TARGET --mabi ilp32 --steps gen -v -o test 2>&1 | tee test/generate.log
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
+          name: generate_code_${{ matrix.test }}_${{ matrix.version }}
           path: |
             test/asm_test/*.S
 
@@ -116,7 +119,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get -qqy update && sudo apt-get -qqy install gcc-riscv64-unknown-elf device-tree-compiler
+        run: sudo apt-get -qqy update && sudo apt-get -qqy install device-tree-compiler
+
+      - name: Install cross-compiler
+        shell: bash
+        run: |
+          echo "deb http://archive.ubuntu.com/ubuntu/ noble main universe" | sudo tee -a /etc/apt/sources.list > /dev/null
+          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install gcc-riscv64-unknown-elf
+          riscv64-unknown-elf-gcc --version
 
       - name: Setup python
         # python dependencies cannot be properly downloaded with new versions of python
@@ -174,9 +184,10 @@ jobs:
             --isa $RISCV_TARGET --mabi ilp32 --steps gcc_compile,iss_sim -v -o test 2>&1 | tee -a test/generate.log
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
+          name: run_tests_log_${{ matrix.test }}_${{ matrix.version }}
           path: |
-            test/asm_test/*.log
             test/*.log
+            test/**/${{ matrix.test }}*.log

--- a/run.py
+++ b/run.py
@@ -670,6 +670,7 @@ def iss_sim(test_list, output_dir, iss_list, iss_yaml, iss_opts,
     for iss in iss_list.split(","):
         log_dir = ("{}/{}_sim".format(output_dir, iss))
         base_cmd = parse_iss_yaml(iss, iss_yaml, isa, priv, setting_dir, debug_cmd)
+        base_cmd += iss_opts
         logging.info("{} sim log dir: {}".format(iss, log_dir))
         run_cmd_output(["mkdir", "-p", log_dir])
         for test in test_list:

--- a/run.py
+++ b/run.py
@@ -446,7 +446,12 @@ def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd):
             if 'gen_opts' in test:
                 # Disable compressed instruction
                 if re.search('disable_compressed_instr', test['gen_opts']):
-                    test_isa = re.sub("c", "", test_isa)
+                    # Note that this substitution assumes the cannonical order
+                    # of extensions, i.e. that extensions with preceding
+                    # underscores will be provided after all letter extensions.
+                    # This assumption should hold true, as this is a
+                    # requirement enforced by e.g. gcc
+                    test_isa = re.sub(r"(rv.+?)c", r"\1", test_isa)
             # If march/mabi is not defined in the test gcc_opts, use the default
             # setting from the command line.
             if not re.search('march', cmd):

--- a/run.py
+++ b/run.py
@@ -827,7 +827,7 @@ def parse_args(cwd):
                             command is not specified")
     parser.add_argument("--isa", type=str, default="",
                         help="RISC-V ISA subset")
-    parser.add_argument("--priv", type=str, default="",
+    parser.add_argument("--priv", type=str, default="m",
                         help="RISC-V privilege modes enabled in simulation [su]")
     parser.add_argument("-m", "--mabi", type=str, default="",
                         help="mabi used for compilation", dest="mabi")
@@ -951,40 +951,40 @@ def load_config(args, cwd):
             args.core_setting_dir = cwd + "/target/" + args.target
         if args.target == "rv32imc":
             args.mabi = "ilp32"
-            args.isa = "rv32imc"
+            args.isa = "rv32imc_zicsr_zifencei"
         elif args.target == "rv32imafdc":
             args.mabi = "ilp32"
-            args.isa = "rv32imafdc"
+            args.isa = "rv32imafdc_zicsr_zifencei"
         elif args.target == "rv32imc_sv32":
             args.mabi = "ilp32"
-            args.isa = "rv32imc"
+            args.isa = "rv32imc_zicsr_zifencei"
         elif args.target == "multi_harts":
             args.mabi = "ilp32"
-            args.isa = "rv32gc"
+            args.isa = "rv32gc_zicsr_zifencei"
         elif args.target == "rv32imcb":
             args.mabi = "ilp32"
-            args.isa = "rv32imcb"
+            args.isa = "rv32imcb_zicsr_zifencei"
         elif args.target == "rv32i":
             args.mabi = "ilp32"
-            args.isa = "rv32i"
+            args.isa = "rv32i_zicsr_zifencei"
         elif args.target == "rv64imc":
             args.mabi = "lp64"
-            args.isa = "rv64imc"
+            args.isa = "rv64imc_zicsr_zifencei"
         elif args.target == "rv64imcb":
             args.mabi = "lp64"
-            args.isa = "rv64imcb"
+            args.isa = "rv64imcb_zicsr_zifencei"
         elif args.target == "rv64gc":
             args.mabi = "lp64"
-            args.isa = "rv64gc"
+            args.isa = "rv64gc_zicsr_zifencei"
         elif args.target == "rv64gcv":
             args.mabi = "lp64"
-            args.isa = "rv64gcv"
+            args.isa = "rv64gcv_zicsr_zifencei"
         elif args.target == "ml":
             args.mabi = "lp64"
-            args.isa = "rv64imc"
+            args.isa = "rv64imc_zicsr_zifencei"
         elif args.target == "rv64imafdc":
             args.mabi = "lp64"
-            args.isa = "rv64imafdc"
+            args.isa = "rv64imafdc_zicsr_zifencei"
         else:
             sys.exit("Unsupported pre-defined target: {}".format(args.target))
     else:

--- a/scripts/instr_trace_compare.py
+++ b/scripts/instr_trace_compare.py
@@ -125,6 +125,8 @@ def compare_trace_csv(csv1, csv2, name1, name2, log,
                         instr_trace_2[trace_2_index].gpr,
                         gpr_val_2)
                     if gpr_state_change_2 == 1:
+                        fd.write("Mismatch[{}]:\n[{}] {} : {}\n".format(
+                            mismatch_cnt, trace_1_index, name1,trace.get_trace_string()))
                         fd.write("{} instructions left in trace {}\n".format(
                           len(instr_trace_2) - trace_2_index, name2))
                         mismatch_cnt += len(instr_trace_2) - trace_2_index

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -88,7 +88,7 @@ def get_env_var(var, debug_cmd=None):
     return val
 
 
-def run_cmd(cmd, timeout_s=999, exit_on_error=1, check_return_code=True,
+def run_cmd(cmd, timeout_s=3600, exit_on_error=1, check_return_code=True,
             debug_cmd=None):
     """Run a command and return output
 

--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -14,6 +14,7 @@ cpu: CPU.{cpu_type} @ sysbus
     cpuType: "{isa}"
     timeProvider: clint
     hartId: 0
+    {priv_levels}
     {additional_cpu_parameters}
 
 clint: IRQControllers.CoreLevelInterruptor  @ sysbus 0x02000000
@@ -83,6 +84,12 @@ def main():
         default="Riscv32",
         help="Renode CPU type",
     )
+    parser.add_argument(
+        "--priv",
+        type=str,
+        default="",
+        help="Supported privilege levels",
+    )
     # Some CPUs might not expose these parameters as configurable
     # allow the testing software to ignore/override them if needed
     parser.add_argument(
@@ -99,6 +106,16 @@ def main():
         repl = os.path.join(tmpdir, "riscv.repl")
         resc = os.path.join(tmpdir, "riscv.resc")
 
+        priv_levels = ""
+        if args.priv:
+            priv_levels += "privilegeLevels: PrivilegeLevels."
+            if "m" in args.priv:
+                priv_levels += "Machine"
+            if "s" in args.priv:
+                priv_levels += "Supervisor"
+            if "u" in args.priv:
+                priv_levels += "User"
+
         params = {
             "renode": args.renode,
             "isa":  args.isa,
@@ -108,6 +125,7 @@ def main():
             "log":  args.log,
             "mem":  args.mem_size,
             "cpu_type": args.cpu_type,
+            "priv_levels": priv_levels,
             "additional_cpu_parameters": args.additional_cpu_parameters,
         }
 

--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -10,11 +10,11 @@ REPL_TEMPLATE = """
 memory: Memory.MappedMemory @ sysbus 0x80000000
     size: {mem}
 
-cpu: CPU.RiscV32 @ sysbus
+cpu: CPU.{cpu_type} @ sysbus
     cpuType: "{isa}"
     timeProvider: clint
     hartId: 0
-    allowUnalignedAccesses: true
+    {additional_cpu_parameters}
 
 clint: IRQControllers.CoreLevelInterruptor  @ sysbus 0x02000000
     [0,1] -> cpu@[3,7]
@@ -77,6 +77,20 @@ def main():
         default="0x100000",
         help="Memory size",
     )
+    parser.add_argument(
+        "--cpu-type",
+        type=str,
+        default="Riscv32",
+        help="Renode CPU type",
+    )
+    # Some CPUs might not expose these parameters as configurable
+    # allow the testing software to ignore/override them if needed
+    parser.add_argument(
+        "--additional-cpu-parameters",
+        type=str,
+        default="allowUnalignedAccesses: true",
+        help="Additional CPU parameters",
+    )
 
     args = parser.parse_args()
 
@@ -93,6 +107,8 @@ def main():
             "resc": resc,
             "log":  args.log,
             "mem":  args.mem_size,
+            "cpu_type": args.cpu_type,
+            "additional_cpu_parameters": args.additional_cpu_parameters,
         }
 
         # Render REPL template

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -40,4 +40,4 @@
 - iss: renode
   path_var: RENODE_PATH
   cmd: >
-    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --mem-size 0x80000000
+    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=m<priv> --mem-size 0x80000000

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --log-commits --isa=<variant> --misaligned -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> --priv=m<priv> --misaligned -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH
@@ -35,7 +35,7 @@
 - iss: whisper
   path_var: WHISPER_ISS
   cmd: >
-    <path_var> <elf> --log --xlen <xlen> --isa <variant> --configfile <config_path>/whisper.json --iccmrw
+    <path_var> <elf> --log --xlen <xlen> --isa <variant><priv> --configfile <config_path>/whisper.json --iccmrw
 
 - iss: renode
   path_var: RENODE_PATH

--- a/yaml/iss.yaml
+++ b/yaml/iss.yaml
@@ -15,7 +15,7 @@
 - iss: spike
   path_var: SPIKE_PATH
   cmd: >
-    <path_var>/spike --log-commits --isa=<variant> --priv=m<priv> --misaligned -l <elf>
+    <path_var>/spike --log-commits --isa=<variant> --priv=<priv> --misaligned -l <elf>
 
 - iss: ovpsim
   path_var: OVPSIM_PATH
@@ -40,4 +40,4 @@
 - iss: renode
   path_var: RENODE_PATH
   cmd: >
-    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=m<priv> --mem-size 0x80000000
+    python3 <scripts_path>/renode_wrapper.py --renode "<path_var>" --elf <elf> --isa <variant> --priv=<priv> --mem-size 0x80000000


### PR DESCRIPTION
This PR introduces the following changes:
* Allows for specifying privilege modes for simulation #984 
* Fixes disabling the `c` extension #988 
* Makes renode_wrapper more configurable #991 