### PR TITLE
Deprecate gen_csr_test.py

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           yum update -y
           yum install -y python39
+          python3.9 -m pip install --upgrade pip setuptools wheel
           python3.9 -m pip install -r requirements.txt
 
       - name: Generate UVM Tests

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -262,10 +262,17 @@ test. All other standard tests do not use this description.
 To specify what ISA width should be generated in the test, simply include the
 matching rv32/rv64/rv128 entry and fill in the appropriate CSR field entries.
 
-Privileged CSR Test Generation (optional)
+Privileged CSR Test Generation (deprecated)
 -----------------------------------------
 
-The CSR generation script is located at `scripts/gen_csr_test.py`_.
+A CSR generation script is located at `scripts/deprecated/gen_csr_test.py`_.
+
+Note that ``riscv_csr_test`` has been deprecated and is no longer supported.
+By default, any invocation that requests it will now return with a message
+stating that the test is deprecated, without generating any CSR test code.
+A new command-line option, ``--enable_deprecated_csr_test``, is provided to
+run the generator anyway for users who still depend on it.
+
 The CSR test code that this script generates will execute every CSR instruction
 on every processor implemented CSR, writing values to the CSR and then using a
 prediction function to calculate a reference value that will be written into
@@ -275,9 +282,9 @@ continue executing, allowing it to be completely self checking. This script has
 been integrated with run.py. If you want to run it separately, you can get the
 command reference with --help::
 
-    python3 scripts/gen_csr_test.py --help
+    python3 scripts/deprecated/gen_csr_test.py --help
 
-.. _scripts/gen_csr_test.py: https://github.com/google/riscv-dv/blob/master/scripts/gen_csr_test.py
+.. _scripts/deprecated/gen_csr_test.py: https://github.com/google/riscv-dv/blob/master/scripts/deprecated/gen_csr_test.py
 
 Adding new instruction stream and test
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/run.py
+++ b/run.py
@@ -235,7 +235,7 @@ def run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
      It calls a separate python script to generate directed CSR test code,
      located at scripts/gen_csr_test.py.
     """
-    cmd = "python3 " + cwd + "/scripts/gen_csr_test.py" + \
+    cmd = "python3 " + cwd + "/scripts/deprecated/gen_csr_test.py" + \
           (" --csr_file {}".format(csr_file)) + \
           (" --xlen {}".format(
               re.search(r"(?P<xlen>[0-9]+)", isa).group("xlen"))) + \
@@ -251,7 +251,8 @@ def run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
 def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
                 csr_file,
                 isa, end_signature_addr, lsf_cmd, timeout_s, log_suffix,
-                batch_size, output_dir, verbose, check_return_code, debug_cmd, target):
+                batch_size, output_dir, verbose, check_return_code, debug_cmd, target,
+                enable_deprecated_csr_test):
     """Run  the instruction generator
 
     Args:
@@ -272,6 +273,7 @@ def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
       verbose               : Verbose logging
       check_return_code     : Check return code of the command
       debug_cmd             : Produce the debug cmd log without running
+      enable_deprecated_csr_test : Allow the deprecated riscv_csr_test to run
     """
     cmd_list = []
     sim_cmd = re.sub("<out>", os.path.abspath(output_dir), sim_cmd)
@@ -286,6 +288,12 @@ def do_simulate(sim_cmd, simulator, test_list, cwd, sim_opts, seed_gen,
         if iterations > 0:
             # Running a CSR test
             if test['test'] == 'riscv_csr_test':
+                if not enable_deprecated_csr_test:
+                    logging.warning(
+                        "riscv_csr_test has been deprecated and is no longer "
+                        "supported. Skipping it. Use --enable_deprecated_csr_test "
+                        "if you still need to run it.")
+                    continue
                 run_csr_test(cmd_list, cwd, csr_file, isa, iterations, lsf_cmd,
                              end_signature_addr, timeout_s, output_dir,
                              debug_cmd)
@@ -409,7 +417,8 @@ def gen(test_list, argv, output_dir, cwd):
                     argv.lsf_cmd,
                     gen_timeout, argv.log_suffix, argv.batch_size,
                     output_dir,
-                    argv.verbose, check_return_code, argv.debug, argv.target)
+                    argv.verbose, check_return_code, argv.debug, argv.target,
+                    argv.enable_deprecated_csr_test)
 
 
 def gcc_compile(test_list, output_dir, isa, mabi, opts, debug_cmd):
@@ -845,6 +854,10 @@ def parse_args(cwd):
                         help="RTL/pyflow simulator setting YAML")
     parser.add_argument("--csr_yaml", type=str, default="",
                         help="CSR description file")
+    parser.add_argument("--enable_deprecated_csr_test", action="store_true",
+                        default=False,
+                        help="Enable the deprecated riscv_csr_test. This test "
+                             "is no longer supported and is disabled by default.")
     parser.add_argument("-ct", "--custom_target", type=str, default="",
                         help="Directory name of the custom target")
     parser.add_argument("-cs", "--core_setting_dir", type=str, default="",
@@ -1069,8 +1082,26 @@ def main():
         c_directed_list = []
 
         if not args.co:
+            # riscv_csr_test has been deprecated. Unless explicitly re-enabled
+            # via --enable_deprecated_csr_test, drop it from the requested tests
+            # and report the deprecation.
+            if not args.enable_deprecated_csr_test:
+                requested_tests = args.test.split(',')
+                if 'riscv_csr_test' in requested_tests:
+                    logging.warning(
+                        "riscv_csr_test has been deprecated and is no longer "
+                        "supported. Use --enable_deprecated_csr_test to run it "
+                        "anyway.")
+                    requested_tests = [t for t in requested_tests
+                                       if t != 'riscv_csr_test']
+                    if not requested_tests:
+                        logging.info("No tests left to run after removing the "
+                                     "deprecated riscv_csr_test. Exiting.")
+                        return
+                    args.test = ','.join(requested_tests)
             process_regression_list(args.testlist, args.test, args.iterations,
-                                    matched_list, cwd)
+                                    matched_list, cwd,
+                                    args.enable_deprecated_csr_test)
             for t in list(matched_list):
                 # Check mutual exclusive between gen_test, asm_test, and c_test
                 if 'asm_test' in t:

--- a/scripts/deprecated/gen_csr_test.py
+++ b/scripts/deprecated/gen_csr_test.py
@@ -27,10 +27,14 @@ To install the bitstring library:
   2) pip install bitstring
 """
 import sys
+import os
 import yaml
 import argparse
 import random
 import copy
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
 from lib import *
 
 try:

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -211,7 +211,7 @@ def run_cmd_output(cmd, debug_cmd=None):
 
 
 def process_regression_list(testlist, test, iterations, matched_list,
-                            riscv_dv_root):
+                            riscv_dv_root, enable_deprecated_csr_test=False):
     """ Get the matched tests from the regression test list
 
     Args:
@@ -219,6 +219,9 @@ def process_regression_list(testlist, test, iterations, matched_list,
       test          : Test to run, "all" means all tests in the list
       iterations    : Number of iterations for each test
       riscv_dv_root : Root directory of RISCV-DV
+      enable_deprecated_csr_test : Allow the deprecated riscv_csr_test to be
+                                   selected even though it is disabled
+                                   (iterations: 0) by default
 
     Returns:
       matched_list : A list of matched tests
@@ -231,10 +234,17 @@ def process_regression_list(testlist, test, iterations, matched_list,
         if 'import' in entry:
             sub_list = re.sub('<riscv_dv_root>', riscv_dv_root, entry['import'])
             process_regression_list(sub_list, test, iterations, matched_list,
-                                    riscv_dv_root)
+                                    riscv_dv_root, enable_deprecated_csr_test)
         else:
             if (entry['test'] in mult_test) or (test == "all"):
                 if iterations > 0 and entry['iterations'] > 0:
+                    entry['iterations'] = iterations
+                # riscv_csr_test is deprecated and disabled (iterations: 0) by
+                # default. When explicitly re-enabled, honor the requested
+                # iteration count so that it can still be run.
+                elif (enable_deprecated_csr_test
+                      and entry['test'] == 'riscv_csr_test'
+                      and iterations > 0):
                     entry['iterations'] = iterations
                 if entry['iterations'] > 0:
                     logging.info("Found matched tests: {}, iterations:{}".format(


### PR DESCRIPTION
This pull-request deprecates, but does not remove, the `gen_csr_test.py` script.  The rationale for this somewhat drastic change:
1. The CSR access-mode configurations (e.g. WPRI, WARL, etc.) are not well supported.
2. CSR testing is now extremely well support by the so-called "[ACT4](https://github.com/riscv/riscv-arch-test)" architecture certification tests supported by RVI.