### PR TITLE
Fix renode_wrapper.py default --cpu-type argument

### DIFF
--- a/scripts/renode_wrapper.py
+++ b/scripts/renode_wrapper.py
@@ -81,7 +81,7 @@ def main():
     parser.add_argument(
         "--cpu-type",
         type=str,
-        default="Riscv32",
+        default="RiscV32",
         help="Renode CPU type",
     )
     parser.add_argument(


### PR DESCRIPTION
`renode_wrapper.py` when `--cpu-type` argument isn't explicitly passed it is defaulted to `Riscv32` which is incorrect and `renode` throws `Error E04: Could not resolve type: 'CPU.Riscv32'.` error.

Solution is just to change the default `cpu_type` argument to `RiscV32`, which is the valid value that should be passed into `.repl` file.